### PR TITLE
fix(webpack): fix webpack error in ReloadServerPlugin

### DIFF
--- a/webpack/ReloadServerPlugin.js
+++ b/webpack/ReloadServerPlugin.js
@@ -41,7 +41,6 @@ class ReloadServerPlugin {
 
         this.workers = [];
 
-        cluster.fork();
       },
     );
   }


### PR DESCRIPTION
The ReloadServerPlugin had a worker termination function, I believe it is not necessary, without it the operation is correct and flawless